### PR TITLE
changed it so it deletes the previous entry in the database if a file…

### DIFF
--- a/Services/AI-Register/AI-Register/DAL/Repositories/FileRepository.cs
+++ b/Services/AI-Register/AI-Register/DAL/Repositories/FileRepository.cs
@@ -15,8 +15,8 @@ public class FileRepository : IFileRepository
 
     public async Task<AISystemFileEntity> AddAiSystemFile(AISystemFileEntity aiSystemFileEntity)
     {
-        AISystemFileEntity? duplicateFileEntity = await _context.AISystemFiles.Where(f => f.Filepath == aiSystemFileEntity.Filepath)
-            .FirstOrDefaultAsync();
+        AISystemFileEntity? duplicateFileEntity = await _context.AISystemFiles
+            .FirstOrDefaultAsync(f => f.Filepath == aiSystemFileEntity.Filepath);
         if (duplicateFileEntity is not null)
         {
             _context.AISystemFiles.Remove(duplicateFileEntity);


### PR DESCRIPTION
… with the same name and content type posted

my reasoning is that there appears to be no quick way to add for example a number to the filepath when it's posted into the filebase.
my recommendation is that a possible warning is added to the frontend that if a file with the same name and type is added a confirmation message will say that the file will be overwritten if they post it